### PR TITLE
Add missing check in in

### DIFF
--- a/src/dict.jl
+++ b/src/dict.jl
@@ -98,6 +98,7 @@ function Base.in(id::Int64, isv::IndexedStructVector)
     comps = getfield(isv, :components)
     del, ID = getfield(isv, :del), getfield(comps, :ID)
     !del && return 1 <= id <= length(ID)
+    id ∈ eachindex(ID) && (@inbounds ID[id] == id) && return true
     id_to_index = getfield(isv, :id_to_index)
     return id in keys(id_to_index)
 end

--- a/test/test-dict.jl
+++ b/test/test-dict.jl
@@ -37,6 +37,7 @@ using Test
         ids_after = collect(keys(s))
         @test length(ids_after) == 3
         @test (2 in ids_after) == false
+        @test 1 ∈ ids_after
 
         push!(s, (num = 111, tag = 'z'))
         new_id = IndexedStructVectors.lastkey(s)


### PR DESCRIPTION
If I understand correctly, `id_to_index` might not contain ids if the index and id are equal.